### PR TITLE
Updating nodejs install instructions to reflect news from nodesource.com

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 
-# List of packags to install
-nodejs_packages: [ 'nodejs', 'nodejs-legacy' ]
+node_version: '0.12'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,10 @@
 # List of base packages to install
 nodejs_base_packages: [ 'nodejs' ]
 
+# .. envvar:: nodejs_prerequisites
+#
+# List of base packages to install
+nodejs_prerequisites: [ 'apt-transport-https' ]
 
 # .. envvar:: nodejs_packages
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Install prerequisites 
+  apt:
+    name: '{{ item }}'
+    state: 'present'
+    install_recommends: False
+  with_flattened:
+    - nodejs_prerequisites
+
 - name: Get upstream APT GPG key
   apt_key:
     id: '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280'
@@ -21,6 +29,7 @@
   apt:
     name: '{{ item }}'
     state: 'present'
+    update_cache: True
     install_recommends: False
   with_flattened:
     - nodejs_base_packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,25 @@
 # Homepage: http://nodejs.org/
 
 # nodejs and npm install based on code from https://github.com/f500/ansible-nodejs
+# As of spring 2015, these articles suggest a different approach:
+# https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions
+# https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories
+#
 
 
-- name: Install NodeJS packages
-  apt: pkg={{ item }} state=latest install_recommends=no
-  with_items: nodejs_packages
+- name: Add Nodejs v0.10 repo
+  shell: curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
+  when: node_version|d() and node_version=='0.10'
 
-  # This will be replaced by a .deb package in the future
-- name: Install npm
-  shell: curl https://www.npmjs.com/install.sh | bash creates=/usr/bin/npm
+- name: Add Nodejs ppa
+  shell: curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
+  when: not node_version or node_version|d() and node_version=='0.12'
+
+- name: Install Nodejs
+  apt: name=nodejs update_cache=yes force=yes
+
+- name: Update npm
+  npm: name=npm global=yes state=latest
 
 - name: Get npm global temporary directory
   command: npm -g config get tmp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,6 @@
 - name: Install Nodejs
   apt: name=nodejs update_cache=yes force=yes
 
-- name: Update npm
-  npm: name=npm global=yes state=latest
-
 - name: Get npm global temporary directory
   command: npm -g config get tmp
   register: nodejs_npm_tempdir


### PR DESCRIPTION
It appears to me that the new "proper" way to install nodejs on Debian based systems has changed some:

https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories

I just thought I'd submit this to put a feeler out for whether or not you'd agree.
