### PR TITLE
Added package list to install only when not installing from upstream.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,16 +14,27 @@
 # List of base packages to install
 nodejs_base_packages: [ 'nodejs' ]
 
+
 # .. envvar:: nodejs_packages
 #
 # List of additional packages to install
 nodejs_packages: []
+
+
+# .. envvar:: nodejs_distribution_packages
+#
+# List of packages which are only needed when NodeJS is installed from Debian.
+nodejs_distribution_packages:
+  - 'nodejs-legacy'
+  - 'npm'
+
 
 # .. envvar:: nodejs_upstream
 #
 # Replace with the version of node.js or io.js you want to install, it should take the following
 # form: node_0.10, node_0.12 or iojs_1.x, iojs_2.x, or False to disable.
 nodejs_upstream: 'node_0.12'
+
 
 # .. envvar:: nodejs_upstream_repository
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,15 @@
     - nodejs_base_packages
     - nodejs_packages
 
+- name: Install packages when not installing from upstream
+  apt:
+    name: '{{ item }}'
+    state: 'present'
+    install_recommends: False
+  when: not nodejs_upstream|d()
+  with_flattened:
+    - nodejs_distribution_packages
+
 - name: Install npm global packages
   npm:
     name: '{{ item.name | default(item) }}'


### PR DESCRIPTION
As of Jessie installing NodeJs from Debian works nicely but there are additional packages needed to get the same functionality as what upstream has packaged into the nodejs package.

Tested with latest Etherpad Lite version. https://github.com/ether/etherpad-lite/commit/a09044a6f3fa610d23b45dbcef675ee4b6b6395b