### PR TITLE
Mention support for node > 4 and set the default version to 6.x.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,13 +30,19 @@ nodejs__upstream: False
 #
 # - ``node_4.x``
 #
+# - ``node_5.x``
+#
+# - ``node_6.x``
+#
+# - ``node_7.x``
+#
 # - ``iojs_1.x``
 #
 # - ``iojs_2.x``
 #
 # If you switch to the ``iojs`` version, you need to update the list of
 # installed APT packages manually.
-nodejs__upstream_version: 'node_4.x'
+nodejs__upstream_version: 'node_6.x'
 
 
 # .. envvar:: nodejs__upstream_key_id


### PR DESCRIPTION
Set the default to node v6.x because the last version (v7.x) does
not support wheezy and precise.